### PR TITLE
Update chart to include ssl

### DIFF
--- a/charts/bitgo-express/Chart.yaml
+++ b/charts/bitgo-express/Chart.yaml
@@ -4,7 +4,7 @@ description: A helm chart to deploy the bitgo application @zap-strike-sandbox.ia
 
 type: application
 version: 0.1.0
-appVersion: "0.1.1"
+appVersion: "0.1.2"
 
 keywords:
   - bitgo

--- a/charts/bitgo-express/templates/bitgo-ssl-cert.yaml
+++ b/charts/bitgo-express/templates/bitgo-ssl-cert.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.ssl.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.ssl.secretName }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .Values.ssl.cert | b64enc }}
+  tls.key: {{ .Values.ssl.key | b64enc }}
+{{- end }}

--- a/charts/bitgo-express/templates/deployment.yaml
+++ b/charts/bitgo-express/templates/deployment.yaml
@@ -53,14 +53,45 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: /api/v2/ping
               port: http
+              {{- if .Values.ssl.enabled }}
+              scheme: HTTPS
+              {{- else }}
+              scheme: HTTP
+              {{- end }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           readinessProbe:
             httpGet:
-              path: /
+              path: /api/v2/ping
               port: http
+              {{- if .Values.ssl.enabled }}
+              scheme: HTTPS
+              {{- else }}
+              scheme: HTTP
+              {{- end }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.ssl.enabled }}
+          volumeMounts:
+            - name: bitgo-ssl-cert
+              mountPath: {{ .Values.ssl.path }}
+              readOnly: true
+          {{- end }}
+      {{- if .Values.ssl.enabled }}
+      volumes:
+        - name: bitgo-ssl-cert
+          secret:
+            secretName: {{ .Values.ssl.secretName }}
+            items:
+              - key: tls.crt
+                path: tls.crt
+              - key: tls.key
+                path: tls.key
+       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/bitgo-express/values.yaml
+++ b/charts/bitgo-express/values.yaml
@@ -23,6 +23,16 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+readinessProbe:
+  path: /api/v2/ping
+  initialDelaySeconds: 30
+  periodSeconds: 10
+
+livenessProbe:
+  path: /api/v2/ping
+  initialDelaySeconds: 30
+  periodSeconds: 10
+
 podAnnotations: {}
 
 podSecurityContext: {}
@@ -38,7 +48,17 @@ securityContext: {}
 
 service:
   type: ClusterIP
-  port: 80
+  port: 3080
+
+# Whether to require SSL.  This is disabled by default.  Disabling SSL will also require
+# diabling SSL in Bitgo if running in a production environment.
+# https://developers.bitgo.com/guides/get-started/express/reference
+ssl:
+  enabled: false
+  # secretName:
+  # key:
+  # cert:
+  # path:
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
@@ -66,13 +86,20 @@ tolerations: []
 affinity: {}
 
 vault:
-  enabled: true
+  enabled: false
   # This role grants access to the following paths in Vault
   # - <service-account-name>/*
   # - restricted/<service-account-name/*
-  role: zap-service-account-path-restricted
+  role: "" #zap-service-account-path-restricted
   extraAnnotations: {}
 
 annotations: {}
 
+# Add environment variables that will be added to the bitgo container.
 env: {}
+  # NODE_ENV: production
+  # BITGO_ENV: prod
+  # BITGO_PORT: 3080
+  # BITGO_DISABLE_SSL: true
+  # BITGO_KEYPATH: /etc/ssl/certs/tls.key
+  # BITGO_CRTPATH: /etc/ssl/certs/tls.crt


### PR DESCRIPTION
This PR adds support for HTTPS as recommended by BitGo.  This could be useful when we run a service mesh in the cluster and require TLS between pod to pod communication.

Right now within the cluster, pods communicate over HTTP.